### PR TITLE
Update game display text in ShowGameState

### DIFF
--- a/lib/show-game.dart
+++ b/lib/show-game.dart
@@ -15,13 +15,14 @@ class ShowGame extends StatefulWidget {
   ShowGameState createState() => ShowGameState();
 }
 
+// This shows the game to the user. They can tap to get a new game.
 class ShowGameState extends State<ShowGame> {
   @override
   Widget build(BuildContext context) {
     var game = widget.game;
     return InkWell(
       child: Text(
-          "$game",
+          "$game name goes here",
         style: TextStyle(fontSize: 18, color: Colors.indigo[700]),
       ),
       onTap: () {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the displayed text in ShowGameState to "$game name goes here" for clearer labeling, and added a comment noting users can tap to get a new game.

<sup>Written for commit 39404d0a3f46f370023169caac01a386ab5e7e5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated game name display to show placeholder text instead of actual game names.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->